### PR TITLE
preserve non-enumerable error properties if possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 var through = require('through')
 var serialize = require('stream-serializer')()
-var getOwnPropertyNames = Object.getOwnPropertyNames || Object.keys || function(obj) {
-  var ret = []
+
+function allKeys(obj) {
+  var ret = Object.getOwnPropertyNames
+    ? Object.getOwnPropertyNames(obj)
+    : []
   for(var k in obj)
     ret.push(k)
   return ret
@@ -21,7 +24,7 @@ module.exports = function (obj, raw) {
   function flattenError(err) {
     if(!(err instanceof Error)) return err
     var err2 = { message: err.message }
-    var props = getOwnPropertyNames(err)
+    var props = allKeys(err)
     for(var i=0; i<props.length; i++)
       err2[props[i]] = err[props[i]]
     return err2

--- a/test/error.js
+++ b/test/error.js
@@ -24,3 +24,26 @@ test('error', function (t) {
     t.equal(err.bar, 'baz', 'non enumerable properties')
   })
 })
+
+test('error custom prototype', function (t) {
+  t.plan(2)
+
+  function CustomError() {
+    Error.call(this)
+    this.message = 'oops'
+  }
+  CustomError.prototype = new Error
+  CustomError.prototype.pro = 'to'
+
+  var b = rpc()
+  b.pipe(rpc({
+    hello: function (args, cb) {
+      cb(new CustomError('oops'))
+    }
+  })).pipe(b)
+
+  b.createRemoteCall('hello')(function (err) {
+    t.ok(err instanceof Error, 'instanceof')
+    t.equal(err.pro, 'to', 'prototype properties')
+  })
+})


### PR DESCRIPTION
this ensures that if the js host supports non enumerable properties, they're copied over to the error clone. Without this patch, LevelUp error objects will be missing their `type` property after going over the wire.
